### PR TITLE
[2021.02.17] jerimo 예산 문제풀이

### DIFF
--- a/5.이진탐색/예산_jerimo.cpp
+++ b/5.이진탐색/예산_jerimo.cpp
@@ -1,0 +1,79 @@
+#include <iostream>
+#include <cstdlib>
+#include <vector>
+#include <list>
+#include <string>
+#include <set>
+#include <algorithm>
+using namespace std;
+
+int n = 0;
+long m = 0; // 10^6을 넘어감
+vector<int> v;
+long sum = 0; // 얘도 long으로 잡아줌
+
+void findCost() {
+	// 방법 1: 예산의 최솟값부터 최댓값까지 이진탐색으로 다 검사
+	// 방법 2: 최솟값이어야 할까? 중간값부터 가능할거 같은데
+	// 근데 이진탐색은 찾는거잖아..
+
+	// 다른 코드를 보니, 이진탐색이긴 한데, mid를 예산으로 생각하고
+	// 그 합을 계산, 합을 m과 비교해서 이진탐색
+	// 근데 이진탐색하는 범위가 v안에서 1씩 증가시키면서
+
+
+	// 1 5 6 100 예산 18인 경우처럼
+	// 내 방법은 예산을 기준으로 탐색하니까 빠르긴한데
+	// 커버 못치는 부분이 존재. 
+	// m을 가지고 이분탐색을 하며 구해야 정확하게 구할 수 있음
+
+
+	int lo = 0;
+	int hi = m;
+	int mid = 0;
+	int rst = 0;
+	long long sum = 0;
+	while (lo <= hi) {
+		mid = (lo + hi) / 2;
+		sum = 0;
+		// mid값을 기준으로 총 예산을 계산해봄
+		for (int i = 0; i < n; i++) {
+			if (v[i] <= mid) {
+				sum += v[i];
+			}
+			else sum += mid;
+		}
+
+		if (sum <= m) {
+			rst = mid;
+			lo = mid + 1;
+		}
+		else {
+			hi = mid - 1;
+		}
+	}
+
+	cout << rst;
+	return;
+}
+
+int main() {
+	cin >> n;
+	int x = 0;
+for (int i = 0; i < n; i++) {
+		scanf("%d", &x);
+		v.push_back(x);
+		sum += x;
+	}
+	cin >> m;
+	sort(v.begin(), v.end());
+	if (sum <= m) {
+		// 정렬한 뒤이므로 맨 뒤의 원소가 최댓값
+		printf("%d", v.back());
+	}
+	else {
+		// 계산된 정수 상한액이 최댓값임
+		findCost();
+	}
+	return 0;
+}


### PR DESCRIPTION
## 삽질

- 첨에 문제 보고 이해하는데 시간이 좀 걸렸다.. 이걸 이진탐색으로 어케 풀라는거지 싶었다.
- 예제 출력을 보고서 첨에 짠 코드는 m/n한 예산의 평균을 구하고, sorting 된 예산 배열(v)에서 평균보다 작은 예산에서 평균-v[i]한 남는 예산을 계산, 그걸 평균보다 큰 예산의 개수만큼 나누고 그걸 평균에 더하는 방식이었다.
- 저대로 하면 예제 출력은 잘 출력되는데(앵간한건 어느정도 커버 되는 듯 했다.) 4 \n 1 5 6 100 \n 18인 경우 내 코드대로 하면 4가 나오는데 4로 했을때의 예산은 13이고 18보다 작으니까 되긴 하는데 예산을 6으로 주면 딱 18이어서 이게 최대값이 된다.
- 한마디로 배열을 가지고 이진탐색을 하니까 평균에서 미세하게 +-한 값을 확인하지 못하게 되는 것이다.
- 그래서 다른 코드를 찬찬히 뜯어보고 다시 방향을 잡았다

## 문제풀이
- 이진탐색을 하되, m과 0을 가지고 시작. 거기서 나오는 mid값을 예산으로 생각하고 시뮬레이션을 한다.(mid보다 작은 예산은 그대로 더하고 크면 mid를 더함)
- 그 합을 m과 비교해서 이진탐색 진행! 
- (근데 여기서도 sum초기화 안해주는 아주 기본적인 실수를 해서,, 좀 헤맸다.)

이 문제는 만약 이진탐색이라고 안알려줬으면 어떤 알고리즘으로 풀어야 할지 되게 막막했을것 같다... 보자마자 어떤식으로 풀어야할지 감이 바로 안왔던 문제는 오랜만,,