### PR TITLE
[2021.02.16] jerimo 공유기 설치 문제풀이

### DIFF
--- a/5.이진탐색/공유기설치_jerimo.cpp
+++ b/5.이진탐색/공유기설치_jerimo.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <cstdlib>
+#include <vector>
+#include <list>
+#include <string>
+#include <set>
+#include <algorithm>
+using namespace std;
+
+int n = 0;
+int c = 0;
+vector<long long> v;
+
+long long dist = 0;
+
+void binary() {
+	int lo = 1; // 수직선 범위의 시작과
+	int hi = v[n - 1] - v[0]; // 끝
+	// 그러니까 배열의 길이가 아닌 그 안에 들어있는 거리가 기준
+	// 저번의 예산 문제에서도 배열의 길이로 접근했다가 틀렸었음
+	int mid = 0;
+	int cnt = 0;
+	int gap = 0; // 간격
+	while (lo <= hi) {
+		mid = (hi + lo) / 2;
+		// mid가 간격이 되는거임
+		// 그래서 mid에 설치하고 mid만큼 떨어진 쪽에 또 설치
+		// 설치하고 나면 거기서부터 다시 시작이니까 start를 v[i]로
+		int start = v[0];
+		cnt = 1; // 첫 번째 집에는 무조건 설치
+		for (int i = 1; i < n; i++) {
+			gap = v[i] - start;
+			if (mid <= gap) {
+				// 설치된 집에서부터 다음 설치까지의 gap이
+				// mid보다 크거나 같아야함
+				cnt++;
+				start = v[i];
+			}
+		}
+		if (cnt < c) {
+			// 공유기 설치가 아직 안끝났으면 간격을 좁혀서 다시
+			hi = mid - 1;
+		}
+		else {
+			dist = mid;
+			lo = mid + 1;
+		}
+	}
+	return;
+}
+
+int main() {
+	cin >> n >> c;
+	long long x = 0;
+	for (int i = 0; i < n; i++) {
+		cin >> x;
+		v.push_back(x);
+	}
+	sort(v.begin(), v.end());
+
+	if (c == 2) {
+		// c가 2이면 양 끝에 설치하는게 거리 최대
+		cout << v[n - 1] - v[0];
+	}
+	else {
+		binary();
+		cout << dist;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
### 삽질

저번에 풀다가 못풀었던 공유기 설치 문제에 다시 도전해보았다.

- 예산 문제와 같은 실수를 또 했다.. 다음엔 안해야지
- 이진탐색 범위를 전체가 아닌 배열을 기준(배열의 값이 아닌 index로 mid계산하는 식)으로 해서 mid가 띄엄띄엄 계산됐다.
- 그리고 이번 문제는 특히나 이해가 안되서 다른사람의 솔루션을 보고도 이해하는데 시간이 많이 걸렸다..


### 문제풀이
- 일단 lo와 hi는 수직선상 범위(집의 위치)의 시작과 끝이다
- 따라서 각각 1과 v[n-1]-v[0]이다.
- mid는 공유기를 설치할 간격이 된다.
- gap은 for문에서 mid간격을 기준(처음엔 간격이 클꺼고 이진탐색을 통해 간격을 점점 줄여서 1까지간다!!)으로 공유기를 설치할지 말지를 결정한다. (gap이 mid보다 작으면 설치 안함!!!) 
- mid간격=3을 기준으로 0XXX0XXX0 이런식으로 하는게 for문의 역할임
- for문을 통과하고 난 뒤에 아직 공유기 설치가 끝나지 않았다면 간격을 줄여서 다시 설치하고
- 아니라면 그때의 간격이 답이된다.


연속으로 이진탐색 문제를 좀 풀어보니 살짝 감이 오는것 같기도 하다...

이진탐색 문제를 어떻게 판별할지에 대해서 찾아보던 중 백준 질문 답변글에 이런 말이 있어서 퍼왔습니당

**"답이 x이상일 수 있는가?"**
답이 x이상이 아니다 -> 답이 x보다 작은 범위를 탐색
답이 x이상이다 -> 답이 x이상인 범위를 탐색
이런 경우 문제를 이진탐색으로 접근할 수 있다.
