### PR TITLE
[2021.03.17] lys7442 용액 풀이

### DIFF
--- a/5.이진탐색/용액_lys7442.py
+++ b/5.이진탐색/용액_lys7442.py
@@ -1,0 +1,33 @@
+import sys
+n=int(input())
+liquid=list(map(int,input().split()))
+liquid=sorted(liquid)
+
+if(liquid[-1]<0): #전부 음수
+    print(liquid[-2],liquid[-1])
+elif(liquid[0]>0): #전부 양수
+    print(liquid[0],liquid[1])
+else:
+    for i in range(1,len(liquid)):
+        if(liquid[i-1]<0 and liquid[i]>0):
+            border=i #음수와 양수 사이 경계가 되는 지점, border부터 양수
+            break
+    l,r=border,len(liquid)-1
+    closest=[liquid[border-1],liquid[border],abs(liquid[border-1]+liquid[border])] #초기값
+    for nn in range(border-1,-1,-1):
+        while(l<=r):
+            mid=(l+r)//2
+            if(abs(liquid[nn]+liquid[mid])<closest[2]):
+                closest=[liquid[nn],liquid[mid],abs(liquid[nn]+liquid[mid])]
+            if(liquid[nn]+liquid[mid]<0):
+                l=mid+1
+            elif(liquid[nn]+liquid[mid]>0):
+                r=mid-1
+            else: #특성값이 정확히 0
+                break
+        l=r
+        r=len(liquid)-1
+    print(closest[0],closest[1])
+        
+        
+        


### PR DESCRIPTION
```python
import sys
n=int(input())
liquid=list(map(int,input().split()))
liquid=sorted(liquid)

if(liquid[-1]<0): #전부 음수
    print(liquid[-2],liquid[-1])
elif(liquid[0]>0): #전부 양수
    print(liquid[0],liquid[1])
else:
    for i in range(1,len(liquid)):
        if(liquid[i-1]<0 and liquid[i]>0):
            border=i #음수와 양수 사이 경계가 되는 지점, border부터 양수
            break
    l,r=border,len(liquid)-1
    closest=[liquid[border-1],liquid[border],abs(liquid[border-1]+liquid[border])] #초기값
    for nn in range(border-1,-1,-1):
        while(l<=r):
            mid=(l+r)//2
            if(abs(liquid[nn]+liquid[mid])<closest[2]):
                closest=[liquid[nn],liquid[mid],abs(liquid[nn]+liquid[mid])]
            if(liquid[nn]+liquid[mid]<0):
                l=mid+1
            elif(liquid[nn]+liquid[mid]>0):
                r=mid-1
            else: #특성값이 정확히 0
                break
        l=r
        r=len(liquid)-1
    print(closest[0],closest[1])
```
깔끔하지 못한 풀이이지만 간단히 설명하자면

정렬 이후 `전부 양수 or 전부 음수 인 경우` 를 제외하고 나머지 경우에서 음수 부분과 양수부분으로 나눴습니다.
음수부분 중에 가장 큰 수부터 작은 수 차례로 반복문을 돌리며 이진탐색을 시행하였습니다.
가장 0에 가까운 값을 구하기 위해 초기값을 설정하고 계속 갱신합니다.
반복문이 돌아가면서 수가 점점 작아지기 때문에 이진탐색하는 구간도 점점 좁아집니다.
탐색이 끝나고 while문을 탈출할 때 항상 r l 순으로 나오기 때문에 r을 새로운 l로 잡으면 됩니다.
![KakaoTalk_20210317_010540500](https://user-images.githubusercontent.com/49704047/111341570-fd811180-86bc-11eb-8c46-69181a4fde75.jpg)
(처음 문제 풀 때 그렸던 그림입니다. 대충 이런 식으로 예상하고 문제를 풀었어요.)

지금 생각해보면 사실 최악의 경우를 생각했을 때 의미없는 과정인 것 같습니다.
그래서 굳이 음수 양수로 분리하고 계속 구간을 갱신할 필요가 없습니다. 
(오히려 시간이 더 오래걸릴 것 같습니다.)