### PR TITLE
[2021.04.04] lys7442 센서 풀이

### DIFF
--- a/1.그리디알고리즘/센서_lys7442.py
+++ b/1.그리디알고리즘/센서_lys7442.py
@@ -1,0 +1,21 @@
+#각 집중국의 수신 가능 영역의 길이의 합을 최소화
+
+n=int(input()) #센서 개수
+k=int(input()) #집중국 개수
+sensor=list(map(int,input().split())) #센서 좌표
+sensor=sorted(sensor) #좌표 정렬
+
+if(k>n):
+    print(0)
+else:
+    #인접 거리 구하기
+    adjoin=list(map(lambda x : sensor[x]-sensor[x-1], range(1,n))) 
+    #인접 거리 정렬 후 가장 먼 곳부터 K-1개 제거
+    sorted_adjoin=sorted(adjoin,reverse=True)[k-1:] 
+    print(sum(sorted_adjoin))
+
+'''
+K 개수의 섹션으로 나눈 뒤
+그 섹션별 평균 위치에 집중국 설치
+섹션을 나누는 기준: 인접한 거리가 가장 먼 곳
+'''


### PR DESCRIPTION
K개의 집중국을 세워 각 집중국의 수신 가능 영역의 길이의 합을 최소화하는 문제입니다.
저는 K-1개의 경계선을 둬서 K개의 섹션으로 나누고 그 섹션별 평균위치에 집중국을 설치하면 된다고 생각했습니다.
그렇게 문제 해결 방향을 잡고 경계를 두는 기준에 대해 고민했습니다.

이상한 방법에 꽃혀서 그거만 붙잡고 하다가 결국 못풀어서 답을 참고했습니다. 
인접 거리가 가장 먼 부분에 경계선을 두면 됩니다. 
그러면 그 인접거리만큼이 사라지고 남은 인접거리의 합이 최소 길이의 합이 됩니다.

코드 이해를 위해 if/else로 나누었지만 사실은 저부분은 빼도 됩니다.
어짜피 K가 더 많으면 sorted_adjoin이 비어있는 배열이 되기 때문입니다.

```python
#각 집중국의 수신 가능 영역의 길이의 합을 최소화

n=int(input()) #센서 개수
k=int(input()) #집중국 개수
sensor=list(map(int,input().split())) #센서 좌표
sensor=sorted(sensor) #좌표 정렬

if(k>n):
    print(0)
else:
    #인접 거리 구하기
    adjoin=list(map(lambda x : sensor[x]-sensor[x-1], range(1,n))) 
    #인접 거리 정렬 후 가장 먼 곳부터 K-1개 제거
    sorted_adjoin=sorted(adjoin,reverse=True)[k-1:] 
    #남은 인접거리들의 합이 길이의 합의 최소
    print(sum(sorted_adjoin))

'''
K 개수의 섹션으로 나눈 뒤
그 섹션별 평균 위치에 집중국 설치
섹션을 나누는 기준: 인접한 거리가 가장 먼 곳
'''
```  